### PR TITLE
Basic linting

### DIFF
--- a/JungleCalc.ps1
+++ b/JungleCalc.ps1
@@ -1,8 +1,8 @@
 function Get-ML
 {
     param (
-        [double]$gallon,
-        [double]$oz
+        [double] $gallon,
+        [double] $oz
     )
     return ($gallon * 3785) + ($oz * 29.574)
 }
@@ -60,31 +60,32 @@ class Juice
 class Component
 {
     Component(
-        [string]$name,
-        [double]$volume
+        [string] $name,
+        [double] $volume
     )
     {
         $this.Name = $name
         $this.VolumeML = $volume
     }
-    [string]$Name
-    [double]$VolumeML
+
+    [string] $Name
+    [double] $VolumeML
 }
 
 class BoozeComponent : Component
 {
     BoozeComponent(
-        [string]$name,
-        [double]$volume,
-        [double]$proof
+        [string] $name,
+        [double] $volume,
+        [double] $proof
     ) : base($name, $volume)
     {
         $this.Proof = $proof
     }
 
-    [double]$Proof
+    [double] $Proof
 
-    [double]GetAlcoholML()
+    [double] GetAlcoholML()
     {
         return (($this.Proof / 200) * $this.VolumeML)
     }

--- a/JungleCalc.ps1
+++ b/JungleCalc.ps1
@@ -7,8 +7,8 @@ function Get-ML
     return ($gallon * 3785) + ($oz * 29.574)
 }
 
-$AbvFormat = "{0:#0.0% ABV}"
-$GallonFormat = "{0:#,##0.0 gallon(s)}"
+$AbvFormat = '{0:#0.0% ABV}'
+$GallonFormat = '{0:#,##0.0 gallon(s)}'
 
 $Juice = [Juice]::new()
 $Juice.Components += [Component]::new('Cranberry Juice', (Get-ML -oz 16))

--- a/JungleCalc.ps1
+++ b/JungleCalc.ps1
@@ -1,4 +1,5 @@
-function Get-ML {
+function Get-ML
+{
     param (
         [double]$gallon,
         [double]$oz
@@ -22,13 +23,15 @@ Write-Output $Juice.Components | Format-Table
 Write-Output "$($AbvFormat -f $Juice.GetAbv()); $($GallonFormat -f $Juice.GetTotalLiquidGallons())`n"
 
 # Classes
-class Juice{
+class Juice
+{
     [Component[]] $Components
 
     [double] GetTotalLiquidML()
     {
         $totalliquid = 0
-        foreach($liquid in $this.Components){
+        foreach ($liquid in $this.Components)
+        {
             $totalliquid += $liquid.VolumeML
         }
         return $totalliquid
@@ -39,10 +42,12 @@ class Juice{
         return $this.GetTotalLiquidML() / 3785
     }
 
-    [double] GetAbv(){
+    [double] GetAbv()
+    {
         $totalbooze = 0
 
-        foreach($liquid in $this.Components){
+        foreach ($liquid in $this.Components)
+        {
             if ($liquid.GetType() -eq [BoozeComponent])
             {
                 $totalbooze += $liquid.GetAlcoholML()
@@ -52,11 +57,13 @@ class Juice{
     }
 }
 
-class Component{
+class Component
+{
     Component(
         [string]$name,
         [double]$volume
-    ){
+    )
+    {
         $this.Name = $name
         $this.VolumeML = $volume
     }
@@ -64,18 +71,21 @@ class Component{
     [double]$VolumeML
 }
 
-class BoozeComponent : Component{
+class BoozeComponent : Component
+{
     BoozeComponent(
         [string]$name,
         [double]$volume,
         [double]$proof
-    ) : base($name, $volume){
+    ) : base($name, $volume)
+    {
         $this.Proof = $proof
     }
 
     [double]$Proof
 
-    [double]GetAlcoholML() {
+    [double]GetAlcoholML()
+    {
         return (($this.Proof / 200) * $this.VolumeML)
     }
 }


### PR DESCRIPTION
I dunno why the VS Code PowerShell extension didn't catch all this stuff immediately. I think VS Code forces you to manually run linting? The keyboard short cut for "Format Code", also know as linting, is **Shift +Alt + F**. I don't know how to make it automatic.

It was just some simple stuff. The comments for each commit should explain it.